### PR TITLE
Replaced bag.isOpen() by checking bag filename

### DIFF
--- a/rosbag_snapshot/package.xml
+++ b/rosbag_snapshot/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag_snapshot</name>
-  <version>1.0.3</version>
+  <version>1.1.0</version>
   <description>The rosbag_snapshot package</description>
   <author email="kma1660+rsp@gmail.com">Kevin Allen</author>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -311,7 +311,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   MessageQueue::range_t range = message_queue.rangeFromTimes(req.start_time, req.stop_time);
 
   // open bag if this the first valid topic and there is data
-  if (!bag.isOpen() && range.second > range.first)
+  if (bag.getFileName().empty() && range.second > range.first)
   {
     try
     {
@@ -425,7 +425,7 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
   }
 
   // If no topics were subscribed/valid/contained data, this is considered a non-success
-  if (!bag.isOpen())
+  if (bag.getFileName().empty())
   {
     res.success = false;
     res.message = res.NO_DATA_MESSAGE;

--- a/rosbag_snapshot_msgs/package.xml
+++ b/rosbag_snapshot_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag_snapshot_msgs</name>
-  <version>1.0.3</version>
+  <version>1.1.0</version>
   <description>Service and message definitions for rosbag_snapshot</description>
 
   <author email="kma1660+rsp@gmail.com">Kevin Allen</author>


### PR DESCRIPTION
There is no bag::isOpen interface in ros kinetic version of rosbag. Replaced the isOpen in rosbag_snapshot with checking the bag filename to make rosbag_snapshot compatible with ros kinetic. The open and close API of bag file are paired with assign and empty the filename of the bag file, please refer to source file [here](https://github.com/ros/ros_comm/blob/kinetic-devel/tools/rosbag_storage/src/chunked_file.cpp)